### PR TITLE
Added basic package.json for better dependency-management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "chartjs-tsgauge",
+  "version": "1.0.0",
+  "description": "<div align=\"center\">\r     <img src=\"logo.bmp\"/>\r </div>",
+  "main": "Gauge.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kluverua/Chartjs-tsgauge.git"
+  },
+  "author": "",
+  "license": "MIT license",
+  "bugs": {
+    "url": "https://github.com/kluverua/Chartjs-tsgauge/issues"
+  },
+  "homepage": "https://github.com/kluverua/Chartjs-tsgauge#readme"
+}


### PR DESCRIPTION
I added a basic package.json to make it possible to use the repo as a dependency in nodejs, even without publishing it on npm.